### PR TITLE
Add travel definition

### DIFF
--- a/T/Travel_Verb.json
+++ b/T/Travel_Verb.json
@@ -1,0 +1,8 @@
+{
+    "word": "Travel",
+    "definitions": [
+        "make a journey, typically of some length",
+        "(of an object or radiation) move, typically in a constant or predictable way"
+    ],
+    "parts-of-speech": "Verb"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #273 

**Description:**
Adds a definition of the verb form of the word travel

