### PR TITLE
Add words starting with letter U:Unerringly

### DIFF
--- a/U/Unerringly.json
+++ b/U/Unerringly.json
@@ -1,0 +1,8 @@
+{
+    "word": "Unerringly",
+    "definitions": [
+        "Always right or accurate",
+        "undeviatingly accurate throughout; not containing any error or flaw"
+    ],
+    "parts-of-speech": "Adverb"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #452


Description:
The word "Unerringly" has been added along with the definition and the part of speech


