### PR TITLE
Create Disestablishmentarianism.json

### DIFF
--- a/D/https/github.com/Showndarya/Hacktoberfest/new/master/Disestablishmentarianism.json
+++ b/D/https/github.com/Showndarya/Hacktoberfest/new/master/Disestablishmentarianism.json
@@ -1,0 +1,9 @@
+{
+    "word": "Disestablishmentarianism",
+    "definitions": [
+        "refers to campaigns to sever links between church and state, particularly in relation to the Church of England as an established church within the United Kingdom."
+    ],
+    "parts-of-speech": "Noun"
+}
+
+


### PR DESCRIPTION
Disestablishmentarianism refers to campaigns to sever links between church and state, particularly in relation to the Church of England as an established church within the United Kingdom.

The Pull Request resolves Issue #57

Description:
Added difficult word

