### PR TITLE
Add zloty word

### DIFF
--- a/Z/Zap.json
+++ b/Z/Zap.json
@@ -1,0 +1,7 @@
+{
+    "word": "Zap",
+    "definitions": [
+		"destroy or obliterate."
+	],
+    "parts-of-speech": "Verb"
+}

--- a/Z/Zigzags.json
+++ b/Z/Zigzags.json
@@ -1,0 +1,7 @@
+{
+    "word": "Zigzags",
+    "definitions": [
+		"a line or course having abrupt alternate right and left turns."
+	],
+    "parts-of-speech": "Noun"
+}

--- a/Z/Zloty.json
+++ b/Z/Zloty.json
@@ -1,0 +1,7 @@
+{
+    "word": "Zloty",
+    "definitions": [
+		"the basic monetary unit of Poland, equal to 100 groszy."
+	],
+    "parts-of-speech": "Noun"
+}

--- a/Z/Zoo.json
+++ b/Z/Zoo.json
@@ -1,0 +1,7 @@
+{
+    "word": "Zoo",
+    "definitions": [
+        "an establishment which maintains a collection of wild animals, typically in a park or gardens, for study, conservation, or display to the public."
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
{
    "word": "Zloty",
    "definitions": [
		"the basic monetary unit of Poland, equal to 100 groszy."
	],
    "parts-of-speech": "Noun"
}