### PR TITLE
Ate words (Issue #807)

### DIFF
--- a/A/Assimilate.json
+++ b/A/Assimilate.json
@@ -2,7 +2,7 @@
     "word": "Assimilate",
     "definitions": [
         "To take in (information, ideas, or culture) and understand fully."
-        "To cause (something) to resemble; liken."
+        "To cause (something) to resemble."
     ],
     "parts-of-speech": "Verb"
 }

--- a/A/Assimilate.json
+++ b/A/Assimilate.json
@@ -1,8 +1,8 @@
 {
     "word": "Assimilate",
     "definitions": [
-        "To take in (information, ideas, or culture) and understand fully."
-        "To cause (something) to resemble."
+        "To take in (information, ideas, or culture) and understand fully.",
+        "To cause (something) to resemble; liken."
     ],
     "parts-of-speech": "Verb"
 }

--- a/A/Assimilate.json
+++ b/A/Assimilate.json
@@ -1,0 +1,8 @@
+{
+    "word": "Assimilate",
+    "definitions": [
+        "To take in (information, ideas, or culture) and understand fully."
+        "To cause (something) to resemble; liken."
+    ],
+    "parts-of-speech": "Verb"
+}

--- a/A/Associate_adjective.json
+++ b/A/Associate_adjective.json
@@ -1,0 +1,7 @@
+{
+    "word": "Associate",
+    "definitions": [
+        "Joined or connected with an organization or business."
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/A/Associate_noun.json
+++ b/A/Associate_noun.json
@@ -1,0 +1,9 @@
+{
+    "word": "Associate",
+    "definitions": [
+        "A partner or colleague in business or at work."
+        "A person with limited or subordinate membership in an organization."
+        "A concept connected with another."
+    ],
+    "parts-of-speech": "Noun"
+}

--- a/A/Associate_noun.json
+++ b/A/Associate_noun.json
@@ -1,8 +1,8 @@
 {
     "word": "Associate",
     "definitions": [
-        "A partner or colleague in business or at work."
-        "A person with limited or subordinate membership in an organization."
+        "A partner or colleague in business or at work.",
+        "A person with limited or subordinate membership in an organization.",
         "A concept connected with another."
     ],
     "parts-of-speech": "Noun"

--- a/A/Associate_verb.json
+++ b/A/Associate_verb.json
@@ -1,0 +1,7 @@
+{
+    "word": "Associate",
+    "definitions": [
+        "To connect (someone or something) with something else in one's mind."
+    ],
+    "parts-of-speech": "Verb"
+}

--- a/A/Authenticate.json
+++ b/A/Authenticate.json
@@ -1,0 +1,7 @@
+{
+    "word": "Authenticate",
+    "definitions": [
+        "To prove or show (something, especially a claim or an artistic work) to be true or genuine."
+    ],
+    "parts-of-speech": "Verb"
+}

--- a/A/Automate.json
+++ b/A/Automate.json
@@ -1,0 +1,7 @@
+{
+    "word": "Automate",
+    "definitions": [
+        "To convert (a process or facility) to largely automatic operation."
+    ],
+    "parts-of-speech": "Verb"
+}


### PR DESCRIPTION
The Pull Request resolves parts of Issue #807 

As mentioned, following words added:
-Authenticate
-Automate
-Assimilate
-Associate

Followed separate parts-of-speech guidlines for Associate.

Assimilate had tailing semicolon removed as it messes up with JSON parsing.