### PR TITLE
fix: Capitalize parts of speech for Cynicism

### DIFF
--- a/C/Cynicism.json
+++ b/C/Cynicism.json
@@ -4,5 +4,5 @@
     "an inclination to believe that people are motivated purely by self-interest; scepticism.",
     "a school of ancient Greek philosophers, the Cynics."
   ],
-  "parts-of-speech": "noun"
+  "parts-of-speech": "Noun"
 }


### PR DESCRIPTION
The Pull Request resolves Issue #831

Description:
Capitalize parts of speech for Cynicism
