### PR TITLE
added Campanology

### DIFF
--- a/C/Campanology.json
+++ b/C/Campanology.json
@@ -1,0 +1,7 @@
+{
+    "word": "Campanology",
+    "definitions": [
+        "The art or study of bell casting and ringing."
+    ],
+     "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #691 

Description:
Added word Campanology
- Noun
- The art or study of bell casting and ringing.
