### PR TITLE
Added definition for "Sonder", courtesy of the Wiktionary page.

### DIFF
--- a/A/Anatidaephobia.json
+++ b/A/Anatidaephobia.json
@@ -1,0 +1,7 @@
+{
+	"word": "Anatidaephobia",
+	"definitions": [
+		"The fear that one is being constantly watched by a duck."
+	],
+	"parts-of-speech": "Noun"
+}

--- a/S/Sonder.json
+++ b/S/Sonder.json
@@ -1,0 +1,7 @@
+{
+	"word": "Sonder",
+	"definitions": [
+		"The profound feeling of realizing that everyone, including strangers passed in the street, has a life as complex as one's own, which they are constantly living despite one's personal lack of awareness of it."
+	],
+	"parts-of-speech": "Noun"
+}


### PR DESCRIPTION
Description:
Added the word "Sonder" to the S directory.
Added the word "Anatidaephobia" to the A directory.
Definition Sources:
[https://en.wiktionary.org/wiki/sonder](https://en.wiktionary.org/wiki/sonder) 
[https://en.wiktionary.org/wiki/anatidaephobia](https://en.wiktionary.org/wiki/anatidaephobia) 