### PR TITLE
Adding adjective and noun definitions for Extrovert and Peripatetic

### DIFF
--- a/E/Extrovert_adjective.json
+++ b/E/Extrovert_adjective.json
@@ -1,0 +1,7 @@
+{
+    "word": "Extrovert",
+    "definitions": [
+        "of, denoting, or typical of an extrovert"
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/E/Extrovert_noun.json
+++ b/E/Extrovert_noun.json
@@ -1,0 +1,7 @@
+{
+    "word": "Extrovert",
+    "definitions": [
+        "an outgoing, overtly expressive person"
+    ],
+    "parts-of-speech": "Noun"
+}

--- a/M/Meticulous.json
+++ b/M/Meticulous.json
@@ -1,7 +1,7 @@
 {
     "word": "Meticulous",
     "definitions": [
-        "showing great attention to detail; very careful and precise",
+        "showing great attention to detail; very careful and precise"
     ],
     "parts-of-speech": "Adjective"
 }

--- a/M/Meticulous.json
+++ b/M/Meticulous.json
@@ -1,0 +1,7 @@
+{
+    "word": "Meticulous",
+    "definitions": [
+        "showing great attention to detail; very careful and precise",
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/M/Mnemonic_adjective.json
+++ b/M/Mnemonic_adjective.json
@@ -1,0 +1,7 @@
+{
+    "word": "Mnemonic",
+    "definitions": [
+      "aiding or designed to aid the memory"
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/M/Mnemonic_noun.json
+++ b/M/Mnemonic_noun.json
@@ -1,0 +1,7 @@
+{
+    "word": "Mnemonic",
+    "definitions": [
+      "a device such as a pattern of letters, ideas, or associations that assists in remembering something"
+    ],
+    "parts-of-speech": "Noun"
+}

--- a/P/Peripatetic_adjective.json
+++ b/P/Peripatetic_adjective.json
@@ -1,0 +1,8 @@
+{
+    "word": "Peripatetic",
+    "definitions": [
+        "traveling from place to place, especially working or based in various places for relatively short periods",
+        "Aristotelian"
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/P/Peripatetic_noun.json
+++ b/P/Peripatetic_noun.json
@@ -1,0 +1,8 @@
+{
+    "word": "Peripatetic",
+    "definitions": [
+        "a person who travels from place to place",
+        "an Aristotelian philosopher"
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
Adding the word 'Extrovert' and it's definitions to the 'E' folder. Also adding the word 'Peripatetic' to the 'P' folder.