### PR TITLE
Capitalise words

### DIFF
--- a/A/Across_adjective.json
+++ b/A/Across_adjective.json
@@ -1,0 +1,7 @@
+{
+    "word": "Across",
+    "definitions": [
+        "being in a crossed position"
+    ],
+    "parts-of-speech": "Adjective"
+}

--- a/A/Across_adverb.json
+++ b/A/Across_adverb.json
@@ -1,0 +1,9 @@
+{
+    "word": "Across",
+    "definitions": [
+        "in a position reaching from one side to the other",
+        "to or on the opposite side",
+        "so as to be understandable, acceptable, or successful"
+    ],
+    "parts-of-speech": "Adverb"
+}

--- a/A/Across_preposition.json
+++ b/A/Across_preposition.json
@@ -5,5 +5,5 @@
         "expressing position or orientation.",
         "used with an expression of measurement"
     ],
-    "parts-of-speech": "preposition & adverb"
+    "parts-of-speech": "Preposition"
 }


### PR DESCRIPTION
The Pull Request resolves Issue #1397 

Description:
Capitalise `Across`
