### PR TITLE
Added the longest town name

### DIFF
--- a/L/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.json
+++ b/L/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.json
@@ -3,5 +3,5 @@
     "definitions": [
         "a village in NW Wales, in SE Anglesey: reputed to be the longest place name in Great Britain when unabbreviated; means: St Mary's Church in the hollow of the white hazel near the rapid whirlpool of Llandysilio of the red cave"
     ],
-    "parts-of-speech": "noun"
+    "parts-of-speech": "Noun"
 }

--- a/L/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.json
+++ b/L/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.json
@@ -1,0 +1,7 @@
+{
+    "word": "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
+    "definitions": [
+        "a village in NW Wales, in SE Anglesey: reputed to be the longest place name in Great Britain when unabbreviated; means: St Mary's Church in the hollow of the white hazel near the rapid whirlpool of Llandysilio of the red cave"
+    ],
+    "parts-of-speech": "noun"
+}


### PR DESCRIPTION
The longest town name is Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.

It is a legitimate place; https://www.thefreedictionary.com/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch
