### PR TITLE
Title case and sanity checks on files for duplicate words

### DIFF
--- a/A/amend.json
+++ b/A/amend.json
@@ -1,7 +1,0 @@
-{
-    "word": "amend",
-    "definitions": [
-        "make minor changes to(a text,piece of legistlation,etc.) in order to make it fairer or more accurate , or to reflect changing circumstances."
-    ],
-    "parts-of-speech": "Verb"
-}

--- a/C/Crumble_noun.json
+++ b/C/Crumble_noun.json
@@ -1,0 +1,8 @@
+{
+    "word": "Crumble",
+    "definitions": [
+        "A crumble is a dish of British origin that can be made in a sweet or savoury version, although the sweet version is much more common.",
+        "a mixture of flour and fat that is rubbed to the texture of breadcrumbs and cooked as a topping for fruit"
+    ],
+    "parts-of-speech": "Noun"
+}

--- a/C/Crumble_verb.json
+++ b/C/Crumble_verb.json
@@ -1,0 +1,7 @@
+{
+    "word": "Crumble",
+    "definitions": [
+        "break or fall apart into small fragments, especially as part of a process of deterioration."
+    ],
+    "parts-of-speech": "Verb"
+}

--- a/C/crumble
+++ b/C/crumble
@@ -1,7 +1,0 @@
-{
-    "word": "Crumble",
-    "definitions": [
-        "A crumble is a dish of British origin that can be made in a sweet or savoury version, although the sweet version is much more common."
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/G/Gist.json
+++ b/G/Gist.json
@@ -1,8 +1,0 @@
-{
-    "word": "Gist",
-    "definitions": [
-        "the substance or essence of a speech or text",
-        "the real point of an action"
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/G/Git.json
+++ b/G/Git.json
@@ -1,7 +1,0 @@
-{
-    "word": "Git",
-    "definitions": [
-        "an unpleasant or contemptible person."
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/G/Glacier.json
+++ b/G/Glacier.json
@@ -1,7 +1,0 @@
-{
-    "word": "Glacier",
-    "definitions": [
-        "A large body of ice moving slowly down a slope or valley or spreading outward on a land surface."
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/G/gambit.json
+++ b/G/gambit.json
@@ -1,8 +1,0 @@
-{
-    "word": "Gambit",
-    "definitions": [
-        "(in chess) an opening move in which a player makes a sacrifice, typically of a pawn, for the sake of a compensating advantage.",
-        "an act or remark that is calculated to gain an advantage, especially at the outset of a situation."
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/G/gist.json
+++ b/G/gist.json
@@ -1,8 +1,0 @@
-{
-    "word": "Gist",
-    "definitions": [
-        "the substance or general meaning of a speech or text.",
-        "essence"
-    ],
-    "parts-of-speech": "Noun"
-}

--- a/W/Wanderlust.json
+++ b/W/Wanderlust.json
@@ -1,8 +1,0 @@
-{
-    "word": "Wanderlust",
-    "definitions": [
-        "a strong desire to travel."
-    ],
-     "parts-of-speech": "Noun"
-}
-

--- a/W/wanderlust.json
+++ b/W/wanderlust.json
@@ -1,7 +1,0 @@
-{
-    "word": "wanderlust",
-    "definitions": [
-        "a strong desire to travel"
-    ],
-    "parts-of-speech": "Noun"
-}


### PR DESCRIPTION
The Pull Request resolves Issue #[1397] in addition to removal of some duplicate words.

Description:
Title cased all files in repo and the following:

renamed "crumble" file to "Crumble_noun.json"
added "Crumble verb" in file "Crumble_verb.json"
removed "gambit.json" as this was a duplicate word
removed "gist.json" as this was a duplicate word
removed "git.json" as this was a duplicate word
removed "Glacier.json" as this was a duplicate word
removed "amend.json" as this was a duplicate word
removed "wanderlust.json" as this was a duplicate word
