### PR TITLE
Added Hummock

### DIFF
--- a/H/Hummock_noun.json
+++ b/H/Hummock_noun.json
@@ -1,0 +1,10 @@
+{
+    "word": "Hummock",
+    "definitions": [
+        "Also hammock. an elavated tract of land rising above the general level of a marshy region.",
+        "A shop or a department within a larger store that sells items used in sewing.",
+        "a knoll or hillock.",
+        "Also, hommock. a ridge in an ice field."
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #597 

Description:
{
    "word": "Hummock",
    "definitions": [
        "Also hammock. an elavated tract of land rising above the general level of a marshy region.",
        "A shop or a department within a larger store that sells items used in sewing.",
        "a knoll or hillock.",
        "Also, hommock. a ridge in an ice field."
    ],
    "parts-of-speech": "Noun"
}

