### PR TITLE
Added Quinquefoliate

### DIFF
--- a/Q/Quinquefoliate_adjective.json
+++ b/Q/Quinquefoliate_adjective.json
@@ -1,0 +1,7 @@
+{
+    "word": "Quinquefoliate",
+    "definitions": [
+        "(of leaves) having or consisting of five leaflets"
+    ],
+    "parts-of-speech": "Adjective"
+}


### PR DESCRIPTION
Added adjective Quinquefoliate.

Meaning:
(of leaves) having or consisting of five leaflets.

Peace!!