### PR TITLE
Astral 

### DIFF
--- a/A/Astral.json
+++ b/A/Astral.json
@@ -1,0 +1,7 @@
+{
+  "word": "Astral",
+  "definitions": [
+    "relating to a supposed non-physical realm of existence to which various psychic and paranormal phenomena are ascribed, and in which the physical human body is said to have a counterpart."
+  ],
+  "parts-of-speech": "Adjective"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #1822 

Description:
Adding word Astral to database


{
  "word": "Astral",
  "definitions": [
    "relating to a supposed non-physical realm of existence to which various psychic and paranormal phenomena are ascribed, and in which the physical human body is said to have a counterpart."
  ],
  "parts-of-speech": "Adjective"
}
