### PR TITLE
[+] Add a noun 'shebang' in `S`: Shebang_noun.json

### DIFF
--- a/S/Shebang_noun.json
+++ b/S/Shebang_noun.json
@@ -1,0 +1,8 @@
+{
+    "word": "Shebang",
+    "definitions": [
+        "a matter, operation, or set of circumstances",
+        "a rough hut or shelter"
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The pull request update the word Shebang [#1822 

Description:
Shebang is a a matter, operation, or set of circumstances sometimes show up in the top sight of the file for point the shell where the execute program use for that file. As a Linux user - i really sad when this word is not in out dict.

Have a good day!.