### PR TITLE
Create Alsike_noun.json

### DIFF
--- a/A/Alsike_noun.json
+++ b/A/Alsike_noun.json
@@ -1,0 +1,7 @@
+{
+    "word": "Alsike",
+    "definitions": [
+        "a tall clover which is widely grown for fodder, native to Europe and naturalized in North America."
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #2736 

Description:
Added word Alsike which means a tall clover which is widely grown for fodder, native to Europe and naturalized in North America.


