### PR TITLE
adding genipap definition

### DIFF
--- a/G/Genipap_noun.json
+++ b/G/Genipap_noun.json
@@ -1,0 +1,8 @@
+{
+    "word": "Genipap",
+    "definitions": [
+        "A tropical American tree, Genipa americana, of the madder family, bearing an edible fruit used for preserves or in making beverages.",
+        "The fruit itself."
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The genipap definition was missing

Description:
Many words are missing. Genipap is one of them, and thus has been added with this PR
