### PR TITLE
Added Eunoia Word

### DIFF
--- a/E/Eunoia_noun.json
+++ b/E/Eunoia_noun.json
@@ -1,0 +1,7 @@
+{
+  "word": "Eunoia",
+  "definitions": [
+    "beautiful thinking; a good mind"
+  ],
+  "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #3273 

Description:
Add all the definitions of Eunoia in a file named Eunoia_noun.json in the folder E

Notes: Delete all the text including this!
* The `#3273` should be replaced with the specific Issue being referenced.
