### PR TITLE
adding the word "Zonoid" to folder Z

### DIFF
--- a/Z/zonoid.json
+++ b/Z/zonoid.json
@@ -1,0 +1,7 @@
+{
+    "word": "zonoid",
+    "definitions": [
+        "a finite vector sum of line segments"
+    ],
+    "parts-of-speech": "Noun"
+}


### PR DESCRIPTION
The Pull Request resolves Issue #3327

Description:
Add all the definitions of Zonoid in a file named Zonoid.json in folder Z


