### PR TITLE
Enormity_noun

### DIFF
--- a/E/Enormity2_noun.json
+++ b/E/Enormity2_noun.json
@@ -1,0 +1,9 @@
+{
+    "word": "Enormity",
+    "definitions": [
+        " extent of something perceived as bad or morally wrong",
+	"a grave crime or sin",
+	"the great or extreme scale, seriousness"
+    ],
+    "parts-of-speech": "noun"
+}


### PR DESCRIPTION
Added word Enormity!
Description:
Although enormity has been used since the late 1700s to denote large size, this usage continues to be disparaged by various language commentators who argue that enormity should be reserved for senses related to "great wickedness." It is enormousness, they insist (a hefty and considerably less common word), that should be used in reference to great size, despite the fact that, like enormity, it too originally was used to denote wickedness or divergence from accepted moral standards. For better or worse, this proscription has been widely ignored by many English speakers, including professional writers. However one chooses to use them, enormity and enormous can both be traced back to the Latin enormis, from the prefix e- ("out of") and norma ("rule," "pattern," or "carpenter's square").
Examples:
 We were shocked at the enormity of the crime.
 They didn't fully grasp the enormity of their decision.



