### PR TITLE
Anti-vaxxer word added

### DIFF
--- a/A/Antivaxxer_noun.json
+++ b/A/Antivaxxer_noun.json
@@ -1,0 +1,7 @@
+{
+    "word": "Anti-vaxxer",
+    "definitions": [
+		"a person who is opposed to vaccination, typically a parent who does not wish to vaccinate their child."
+	],
+    "parts-of-speech": "noun"
+}


### PR DESCRIPTION
This Pull Request adds a new word that has recently been added to the oxford dictionary in light of the pandemic.
Description:
Added the word Anti-vaxxer as the file Antivaxxer_noun.json

